### PR TITLE
Stop rules on exit

### DIFF
--- a/D2SE/MainWindow.xaml.cs
+++ b/D2SE/MainWindow.xaml.cs
@@ -77,12 +77,17 @@ namespace D2SoloEnabler
         // Well lol, could probably do this some other way. Looks stupid with a method for just this.. but whatever honestly.
         private void OnButtonCloseClicked(object sender, RoutedEventArgs e)
         {
+            Application.Current.Shutdown();
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
             // Remove the FW rules before closing the application.
             Soloplay.RemoveFirewallRule(fwRuleName);
 
-            Application.Current.Shutdown();
+            base.OnClosed(e);
         }
-        
+
         private static void OnPropertyIsSoloPlayActiveChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             if (d is MainWindow instance)

--- a/D2SE/MainWindow.xaml.cs
+++ b/D2SE/MainWindow.xaml.cs
@@ -77,6 +77,9 @@ namespace D2SoloEnabler
         // Well lol, could probably do this some other way. Looks stupid with a method for just this.. but whatever honestly.
         private void OnButtonCloseClicked(object sender, RoutedEventArgs e)
         {
+            // Remove the FW rules before closing the application.
+            Soloplay.RemoveFirewallRule(fwRuleName);
+
             Application.Current.Shutdown();
         }
         


### PR DESCRIPTION
This PR removes the firewall rules when the user exits the application (by clicking the X button, or closing it from the taskbar, or even when killing the process in Task Manager). 

My reasoning here is that a user would probably expect the Solo Play functionality to cease when closing the app, and that they may become frustrated if they close the app and still experience solo play and/or longer-than-usual loading times when loading into an activity. Feel free to close this PR if you don't agree, but I think this would be a nice addition. 

Cheers, and thank you for the nice work on this project. 