### PR TITLE
Adding funtionality to toggle original Destiny 2 rules

### DIFF
--- a/D2SE/Helpers/SettingsStore.cs
+++ b/D2SE/Helpers/SettingsStore.cs
@@ -11,9 +11,9 @@ namespace D2SoloEnabler.Helpers
         {
             string regValue = String.Empty;
 
-            RegistryKey key = Registry.CurrentUser.CreateSubKey($"SOFTWARE\\{_softwareName}");
+            RegistryKey key = Registry.CurrentUser.CreateSubKey($@"SOFTWARE\{_softwareName}");
 
-            if(key != null)
+            if (key != null)
             {
                 regValue = (string)key.GetValue(settingName);
             }
@@ -23,8 +23,17 @@ namespace D2SoloEnabler.Helpers
 
         public static void SetSettingValue(string settingName, string settingValue)
         {
-            RegistryKey key = Registry.CurrentUser.CreateSubKey($"SOFTWARE\\{_softwareName}");
+            RegistryKey key = Registry.CurrentUser.CreateSubKey($@"SOFTWARE\{_softwareName}");
             key.SetValue(settingName, settingValue);
+        }
+
+        public static void DeleteSetting(string settingName)
+        {
+            var subKey = Registry.CurrentUser.OpenSubKey($@"SOFTWARE\{_softwareName}", true);
+            if (subKey != null)
+            {
+                subKey.DeleteValue(settingName);
+            }
         }
     }
 }

--- a/D2SE/Models/Soloplay.cs
+++ b/D2SE/Models/Soloplay.cs
@@ -16,8 +16,7 @@ namespace D2SoloEnabler
         /// <returns>true if rule exists, otherwise false.</returns>
         public static bool DoesFWRuleExist(string ruleName)
         {
-            Type tNetFwPolicy2 = Type.GetTypeFromProgID("HNetCfg.FwPolicy2");
-            INetFwPolicy2 fwPolicy2 = (INetFwPolicy2)Activator.CreateInstance(tNetFwPolicy2);
+            INetFwPolicy2 fwPolicy2 = GetPolicy();
 
             foreach (INetFwRule rule in fwPolicy2.Rules)
             {
@@ -30,23 +29,27 @@ namespace D2SoloEnabler
         }
 
         /// <summary>
-        /// Creates a Firewall rule. Use parameters to control name, port, direction and protocol.
+        /// Creates a Firewall rule. Use parameters to control name, application name, port, direction, action and protocol.
         /// </summary>
         /// <param name="ruleName">Name of the rule.</param>
         /// <param name="portValue">Single port: "222". Range: "222-444".</param>
-        /// <param name="isOut">true = outbound rule. False = inbound rule.</param>
-        /// <param name="isUDP">true = UDP. False = TCP.</param>
-        public static void CreateFWRule(string ruleName = "Firewall testing via C#", string portValue = "8000-8005", bool isOut = true, bool isUDP = true)
+        /// <param name="applicationName">Full path to the application the rule will be applied for</param>
+        /// <param name="isBlocking">true = the rule will block traffic, false the rule will allow traffic</param>
+        /// <param name="isOut">true = outbound rule. false = inbound rule.</param>
+        /// <param name="isUDP">true = UDP. false = TCP.</param>
+        public static void CreateFWRule(
+            string ruleName = "Firewall testing via C#",
+            string portValue = "8000-8005",
+            string applicationName = null,
+            bool isBlocking = true,
+            bool isOut = true,
+            bool isUDP = true)
         {
-            Type tNetFwPolicy2 = Type.GetTypeFromProgID("HNetCfg.FwPolicy2");
-            INetFwPolicy2 fwPolicy2 = (INetFwPolicy2)Activator.CreateInstance(tNetFwPolicy2);
-            var currentProfiles = fwPolicy2.CurrentProfileTypes;
-
             // Let's create a new FW rule.
             INetFwRule2 inboundRule = (INetFwRule2)Activator.CreateInstance(Type.GetTypeFromProgID("HNetCfg.FWRule"));
 
             // Block it through firewall
-            inboundRule.Action = NET_FW_ACTION_.NET_FW_ACTION_BLOCK;
+            inboundRule.Action = isBlocking ? NET_FW_ACTION_.NET_FW_ACTION_BLOCK : NET_FW_ACTION_.NET_FW_ACTION_ALLOW;
 
             // Quick description for the rule.
             inboundRule.Description = "Used by the program Solo Enabler. Its use is to enable solo play in Destiny 2.";
@@ -60,14 +63,17 @@ namespace D2SoloEnabler
             // Set the name of the FW rule
             inboundRule.Name = ruleName;
 
+            //Set the application name for the rule if provided
+            if (!string.IsNullOrWhiteSpace(applicationName)) inboundRule.ApplicationName = applicationName;
+
             // Make sure to set the protocol before the ports. TCP = 6. UDP = 17.
-            inboundRule.Protocol = (int)(isUDP ? NetFwTypeLib.NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_UDP : NetFwTypeLib.NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP);
+            inboundRule.Protocol = (int)(isUDP ? NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_UDP : NET_FW_IP_PROTOCOL_.NET_FW_IP_PROTOCOL_TCP);
 
             // Set the ports.
             inboundRule.RemotePorts = portValue;
 
             // Add the rule itself
-            INetFwPolicy2 firewallPolicy = (INetFwPolicy2)Activator.CreateInstance(Type.GetTypeFromProgID("HNetCfg.FwPolicy2"));
+            INetFwPolicy2 firewallPolicy = GetPolicy();
             firewallPolicy.Rules.Add(inboundRule);
         }
 
@@ -89,5 +95,40 @@ namespace D2SoloEnabler
                 }
             }
         }
+
+        /// <summary>
+        /// Try and extract the value for the "ApplicationName" property of the given firewall rule
+        /// <paramref name="appName"/> is null when rule matching "<paramref name="ruleName"/>" is not found
+        /// </summary>
+        /// <param name="ruleName">The name of the rule to look for</param>        
+        /// <param name="appName">The output value. null if property is not found</param>
+        /// <returns><para><c>true</c> if matching rule is found</para><para><c>false</c> if a matching rule is not found</para></returns>
+        internal static bool TryExtractAppNameFromRule(string ruleName, out string appName)
+        {
+            INetFwPolicy2 fwPolicy2 = GetPolicy();
+
+            foreach (INetFwRule2 rule in fwPolicy2.Rules )
+            {
+                if (rule.Name == ruleName)
+                {
+                    object objValue = rule.ApplicationName;
+                    if(objValue != null)
+                    {
+                        appName = Convert.ToString(objValue);
+                        return true;
+                    }
+                }
+            }
+            appName = null;
+            return false;
+        }
+
+        private static INetFwPolicy2 GetPolicy()
+        {
+            Type tNetFwPolicy2 = Type.GetTypeFromProgID("HNetCfg.FwPolicy2");
+            INetFwPolicy2 fwPolicy2 = (INetFwPolicy2)Activator.CreateInstance(tNetFwPolicy2);
+            return fwPolicy2;
+        }
+
     }
 }

--- a/D2SE/pages/Settings.xaml
+++ b/D2SE/pages/Settings.xaml
@@ -28,6 +28,7 @@
                 <RowDefinition Height="auto" />
                 <RowDefinition Height="auto" />
                 <RowDefinition Height="auto" />
+                <RowDefinition Height="auto" />
             </Grid.RowDefinitions>
 
             <Grid.ColumnDefinitions>
@@ -38,6 +39,8 @@
             <CheckBox Name="AlwaysOnTop" Margin="0 5 0 5" Foreground="White" Grid.Column="0" Grid.Row="0">Enable always-on-top</CheckBox>
             
             <CheckBox Name="EnableHotkey" Margin="0 5 0 5" Foreground="White" Grid.Column="0" Grid.Row="1">Enable hotkey (Alt + Shift + K)</CheckBox>
+
+            <CheckBox Name="ToggleGameRules" Margin="0 5 0 5" Foreground="White" Grid.Column="0" Grid.Row="2">Toggle "Destiny 2" rules</CheckBox>
 
         </Grid>
         

--- a/D2SE/pages/Settings.xaml.cs
+++ b/D2SE/pages/Settings.xaml.cs
@@ -18,6 +18,7 @@ namespace D2SoloEnabler.pages
             // Initialize the settings with their proper stored value.
             AlwaysOnTop.IsChecked = Convert.ToBoolean(SettingsStore.GetSettingValue("AlwaysOnTop"));
             EnableHotkey.IsChecked = Convert.ToBoolean(SettingsStore.GetSettingValue("EnableHotkey"));
+            ToggleGameRules.IsChecked = Convert.ToBoolean(SettingsStore.GetSettingValue("ToggleGameRules"));
         }
 
         public event EventHandler Closed;
@@ -33,7 +34,7 @@ namespace D2SoloEnabler.pages
             // Let's just go through the settings one-by-one (which is fine, cuz we've only got one settings... So ye. KISS).
             SettingsStore.SetSettingValue("AlwaysOnTop", AlwaysOnTop.IsChecked.ToString());
             SettingsStore.SetSettingValue("EnableHotkey", EnableHotkey.IsChecked.ToString());
-
+            SettingsStore.SetSettingValue("ToggleGameRules", ToggleGameRules.IsChecked.ToString());
             Closed?.Invoke(this, EventArgs.Empty);
         }
     }


### PR DESCRIPTION
Adds the ability to toggle the original game rules by removing them whenever the app is active and re adding them when the app is deactivated or closed.
There is a separate option in the settings screen for that as well.