### PR TITLE
Add a proper window title

### DIFF
--- a/Destiny2SoloEnabler/MainWindow.xaml
+++ b/Destiny2SoloEnabler/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:Destiny2SoloEnabler"
         xmlns:pages="clr-namespace:Destiny2SoloEnabler.Pages"
         mc:Ignorable="d"
-        Title="Ignored for now, we'll come back to you later" Height="220" Width="270"
+        Title="Destiny 2 Solo Enabler" Height="220" Width="270"
         ResizeMode="NoResize"
         WindowStartupLocation="CenterScreen"
         WindowStyle="None"


### PR DESCRIPTION
This PR adds a proper window title to the window that opens. the current placeholder text is visible in alt-tab view as well as when hovering over it in the task bar
![image](https://github.com/user-attachments/assets/ee6c425d-e259-4a3b-bce4-9c78af554cec)
