### PR TITLE
Fixed #52 - Program would sometimes crash due to failing to get a valid value from settings

### DIFF
--- a/Destiny2SoloEnabler/MainWindow.xaml.cs
+++ b/Destiny2SoloEnabler/MainWindow.xaml.cs
@@ -69,7 +69,7 @@ public partial class MainWindow : Window
         _initializing = false;
 
         // Makes sure the application has the highest z-index of all applications, thus doing the always-on-top.
-        Topmost = Convert.ToBoolean(SettingsService.GetSettingsValue("AlwaysOnTop"));
+        Topmost = SettingsService.GetSettingsBooleanValue("AlwaysOnTop");
     }
 
     private void InitializeResources()
@@ -91,7 +91,7 @@ public partial class MainWindow : Window
 
     private void RemoveHotkey()
     {
-        if (_soloEnablerHotkey != null)
+        if (_soloEnablerHotkey is not null)
         {
             _soloEnablerHotkey.Dispose();
             _soloEnablerHotkey = null;
@@ -101,7 +101,7 @@ public partial class MainWindow : Window
     private void HandleHotkeyRegistration()
     {
         // Find out if we need to have hotkey functionality.
-        _enableHotkey = Convert.ToBoolean(SettingsService.GetSettingsValue("EnableHotkey"));
+        _enableHotkey = SettingsService.GetSettingsBooleanValue("EnableHotkey");
 
         if(!_enableHotkey || _soloEnablerHotkey is not null)
         {

--- a/Destiny2SoloEnabler/Service/SettingsService.cs
+++ b/Destiny2SoloEnabler/Service/SettingsService.cs
@@ -23,6 +23,12 @@ internal static class SettingsService
     public static bool GetSettingsBooleanValue(string settingsName)
     {
         string value = GetSettingsValue(settingsName);
+
+        if (String.IsNullOrEmpty(value))
+        {
+            value = "false";
+        }
+
         return Convert.ToBoolean(value);
     }
 

--- a/Destiny2SoloEnabler/Service/SoloPlayService.cs
+++ b/Destiny2SoloEnabler/Service/SoloPlayService.cs
@@ -31,14 +31,14 @@ internal class SoloPlayService
 
     public void RemoveFirewallRule(string ruleName)
     {
-        if(!DoesFirewallRuleExist(ruleName))
+        if (!DoesFirewallRuleExist(ruleName))
         {
             return;
         }
 
         foreach(INetFwRule rule in _firewallPolicy.Rules)
         {
-            if(rule.Name == ruleName)
+            if (rule.Name == ruleName)
             {
                 _firewallPolicy.Rules.Remove(ruleName);
             }
@@ -66,11 +66,11 @@ internal class SoloPlayService
     public void CreateFirewallRules(FirewallRule rule) 
     {
         // Create a total of 4 rules. Out: true and false. Udp: true and false.
-        for(int i = 0; i < 2; i++)
+        for (int i = 0; i < 2; i++)
         {
-            rule.IsOut = i == 0 ? true : false;
+            rule.IsOut = i == 0;
 
-            for(int j = 0; j < 2; j++)
+            for (int j = 0; j < 2; j++)
             {
                 rule.IsUDP = j == 0 ? true : false;
                 CreateFirewallRule(rule);


### PR DESCRIPTION
Added a check to see if the returned string is empty, if it is, then we use the value "false" rather then String.Empty. 
Replaced all instances in the main overview, where we previously called the GetSettingsValue method directly.